### PR TITLE
Crawler-duplicate-issue

### DIFF
--- a/scrapper/mte/settings.py
+++ b/scrapper/mte/settings.py
@@ -38,9 +38,9 @@ CONCURRENT_REQUESTS_PER_DOMAIN = 1
 
 # Override the default request headers:
 DEFAULT_REQUEST_HEADERS = {
-  'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
-  'Accept-Language': 'fr',
-  'Cache-Control': 'no-store',
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+    "Accept-Language": "fr",
+    "Cache-Control": "no-store",
 }
 
 # Enable or disable spider middlewares

--- a/scrapper/mte/settings.py
+++ b/scrapper/mte/settings.py
@@ -37,10 +37,11 @@ CONCURRENT_REQUESTS_PER_DOMAIN = 1
 # TELNETCONSOLE_ENABLED = False
 
 # Override the default request headers:
-# DEFAULT_REQUEST_HEADERS = {
-#   'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
-#   'Accept-Language': 'en',
-# }
+DEFAULT_REQUEST_HEADERS = {
+  'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+  'Accept-Language': 'fr',
+  'Cache-Control': 'no-store',
+}
 
 # Enable or disable spider middlewares
 # See https://docs.scrapy.org/en/latest/topics/spider-middleware.html

--- a/scrapper/mte/spiders/mte_crawler.py
+++ b/scrapper/mte/spiders/mte_crawler.py
@@ -8,14 +8,17 @@ class MteCrawlerSpider(scrapy.Spider):
     allowed_domains = ["consultations-publiques.developpement-durable.gouv.fr"]
 
     ## Modifier le nom de la consultation ci-dessous
-    _start_url = "http://www.consultations-publiques.developpement-durable.gouv.fr/spip.php?page=article&id_article=2569"
+    _start_url = (
+        "http://www.consultations-publiques.developpement-durable.gouv.fr/"
+        + "projet-de-decret-pris-en-application-de-l-article-a2569.html"
+    )
     # "projet-de-decret-pris-en-application-de-l-article-a2569"
     ## Modifier le nombre de commentaires ci-dessous
-    _max_comments = 4087
+    _max_comments = 100
 
     def start_requests(self):
         ## Création de la liste des pages
-        self.logger.info("Téléchargement de la première page")
+        self.logger.info("Création de la liste des pages à télécharger")
         urls = [
             self._start_url,
         ]
@@ -23,7 +26,6 @@ class MteCrawlerSpider(scrapy.Spider):
             urls.append(
                 self._start_url + "&debut_forums=" + str(page) + "#pagination_forums"
             )
-        print(urls[2])
         for url in urls:
             yield scrapy.Request(url=url, callback=self.parse)
 


### PR DESCRIPTION
Essai de contournement du problème de pages dupliquées, en supprimant le cache. Mais le problème semble bien venir du serveur.
Cependant, cette PR permet de limiter le débit des requêtes au serveur MTE, ce qui évite de le charger trop. A voir s'il faut accélerer le débit par la suite.